### PR TITLE
Put TensorNetwork on the same footing as rest of n3fit

### DIFF
--- a/n3fit/src/n3fit/backends/__init__.py
+++ b/n3fit/src/n3fit/backends/__init__.py
@@ -1,3 +1,9 @@
+from keras import Sequential as KerasSequential
+from keras.layers import Activation as KerasActivation
+
+# Necessary for the Tensor Network
+from tn4ai.layers.keras.tucker import TuckerDense
+
 from n3fit.backends.keras_backend import callbacks, constraints, operations
 from n3fit.backends.keras_backend.MetaLayer import MetaLayer
 from n3fit.backends.keras_backend.MetaModel import (
@@ -9,6 +15,7 @@ from n3fit.backends.keras_backend.MetaModel import (
 from n3fit.backends.keras_backend.base_layers import (
     Concatenate,
     Input,
+    KerasDense,
     Lambda,
     base_layer_selector,
     regularizer_selector,

--- a/n3fit/src/n3fit/backends/keras_backend/operations.py
+++ b/n3fit/src/n3fit/backends/keras_backend/operations.py
@@ -1,29 +1,29 @@
 """
-    This module contains the list of operations that can be used within the
-    ``call`` method of the ``n3fit`` layers as well as operations that can
-    act on layers.
+This module contains the list of operations that can be used within the
+``call`` method of the ``n3fit`` layers as well as operations that can
+act on layers.
 
-    This includes an implementation of the NNPDF operations on fktable in the keras
-    language (with the mapping ``c_to_py_fun``) into Keras ``Lambda`` layers.
+This includes an implementation of the NNPDF operations on fktable in the keras
+language (with the mapping ``c_to_py_fun``) into Keras ``Lambda`` layers.
 
-    The rest of the operations in this module are divided into four categories:
-    numpy to tensor:
-        Operations that take a numpy array and return a tensorflow tensor
-    layer to layer:
-        Operations that take a layer and return another layer
-    tensor to tensor:
-        Operations that take a tensor and return a tensor
-    layer generation:
-        Instanciate a layer to be applied by the calling function
+The rest of the operations in this module are divided into four categories:
+numpy to tensor:
+    Operations that take a numpy array and return a tensorflow tensor
+layer to layer:
+    Operations that take a layer and return another layer
+tensor to tensor:
+    Operations that take a tensor and return a tensor
+layer generation:
+    Instanciate a layer to be applied by the calling function
 
-    Most of the operations in this module are just aliases to the backend
-    (Keras in this case) so that, when implementing new backends, it is clear
-    which operations may need to be overwritten.
-    For a few selected operations, a more complicated wrapper to e.g., make
-    them into layers or apply some default, is included.
+Most of the operations in this module are just aliases to the backend
+(Keras in this case) so that, when implementing new backends, it is clear
+which operations may need to be overwritten.
+For a few selected operations, a more complicated wrapper to e.g., make
+them into layers or apply some default, is included.
 
-    Note that tensor operations can also be applied to layers as the output of a layer is a tensor
-    equally operations are automatically converted to layers when used as such.
+Note that tensor operations can also be applied to layers as the output of a layer is a tensor
+equally operations are automatically converted to layers when used as such.
 """
 
 from keras import backend as K
@@ -48,6 +48,7 @@ from keras.ops import (
     reshape,
     repeat,
     split,
+    squeeze,
     sum,
     tanh,
     transpose,

--- a/n3fit/src/n3fit/checks.py
+++ b/n3fit/src/n3fit/checks.py
@@ -135,7 +135,7 @@ def check_initializer(initializer):
 def check_layer_type_implemented(parameters):
     """Checks whether the layer_type is implemented"""
     layer_type = parameters.get("layer_type")
-    implemented_types = ["dense", "dense_per_flavour"]
+    implemented_types = ["dense", "dense_per_flavour", "tensor_network"]
     if layer_type not in implemented_types:
         raise CheckError(
             f"Layer type {layer_type} not implemented, must be one of {implemented_types}"
@@ -431,7 +431,7 @@ def check_consistent_parallel(parameters, parallel_models):
     """
     if not parallel_models:
         return
-    if parameters.get("layer_type") not in ("dense"):
+    if parameters.get("layer_type") not in ("dense", "tensor_network"):
         raise CheckError(
             "Parallelization has only been tested with layer_type=='dense', set `parallel_models: false`"
         )

--- a/n3fit/src/n3fit/model_gen.py
+++ b/n3fit/src/n3fit/model_gen.py
@@ -27,9 +27,13 @@ from n3fit.backends import (
     NN_PREFIX,
     PREPROCESSING_LAYER_ALL_REPLICAS,
     Input,
+    KerasActivation,
+    KerasDense,
+    KerasSequential,
     Lambda,
     MetaLayer,
     MetaModel,
+    TuckerDense,
     base_layer_selector,
 )
 from n3fit.backends import operations as op
@@ -871,6 +875,31 @@ def _generate_nn(
                 activation=activation,
                 regularizer=reg,
             )
+
+    elif architecture == "tensor_network":
+        # When in "tensor_network" mode
+        # the layers as such that:
+        #
+        # 1. First layer is a Dense
+        # 2. Second and third layer are TuckerDense
+        # 4. Then a linear dense nodes_out to nodes_out is generated
+
+        layer_map = [
+            Lambda(lambda xi: op.squeeze(xi, axis=0), input_shape=(1, None, 2)),
+            KerasDense(nodes[0], input_shape=(2,)),
+            KerasActivation(activations[0]),
+            TuckerDense(nodes[0], nodes[1], in_ranks=(2,), out_ranks=(2, 2)),
+            KerasActivation(activations[1]),
+            TuckerDense(nodes[1], nodes[2], in_ranks=(2, 2), out_ranks=(2,)),
+            KerasActivation(activations[2]),
+            KerasDense(nodes[3], activation=activations[3]),
+            Lambda(lambda xi: op.expand_dims(xi, axis=0)),
+        ]
+
+        nodes = activations = [None] * len(layer_map)
+
+        def layer_generator(i_layer, *_args):
+            return layer_map[i_layer]
 
     else:
         raise ValueError(f"{architecture=} not recognized during model generation")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,7 +62,8 @@ python = ">=3.9"
 matplotlib = "^3.9"
 pineappl = "^1.0.0"
 pandas = "*"
-numpy = "*"
+# tn4ai (private package) requires this version of numpy
+numpy = "^2.0.0"
 "ruamel.yaml" = "*"
 validobj = "*"
 prompt_toolkit = "*"
@@ -72,7 +73,8 @@ packaging = "*"
 psutil = "*"
 tensorflow = "*"
 keras = "^3.1"
-eko = "^0.15.1"
+# the eko from master is not compatible with numpy > 2
+eko = { git = "https://github.com/NNPDF/eko", branch = "support_3point13" }
 joblib = "*"
 # Hyperopt
 hyperopt = "*"

--- a/validphys2/src/validphys/photon/compute.py
+++ b/validphys2/src/validphys/photon/compute.py
@@ -8,8 +8,12 @@ from scipy.integrate import trapezoid
 from scipy.interpolate import interp1d
 import yaml
 
-from eko import basis_rotation
-from eko.io import EKO
+try:
+    from eko import basis_rotation
+    from eko.io import EKO
+except Exception:
+    basis_rotation = None
+    EKO = None
 from n3fit.io.writer import XGRID
 from validphys.n3fit_data import replica_luxseed
 


### PR DESCRIPTION
As per the title.

Instead of using a sequential model which is then recasted into the functional API, it uses the functional API directly. @BrunoLiegiBastonLiegi the runcards you are using with the other branch _should_ work here just the same, only now you can actually run multiple replicas on GPU (which will be useful once the hyperopt finishes to run the best model).

So now you can use the runcard to define the network (always Dense - TD - TD - Dense, but making it more flexible would be trivial)

```yaml
nodes_per_layer: [25, 20, 8, 8]
activation_per_layer: [tanh, tanh, tanh, linear]
```

and this is then used by the generator to define a list of layers

```python
        layer_map = [
            Lambda(lambda xi: op.squeeze(xi, axis=0), input_shape=(1, None, 2)),
            KerasDense(nodes[0], input_shape=(2,)),
            KerasActivation(activations[0]),
            TuckerDense(nodes[0], nodes[1], in_ranks=(2,), out_ranks=(2, 2)),
            KerasActivation(activations[1]),
            TuckerDense(nodes[1], nodes[2], in_ranks=(2, 2), out_ranks=(2,)),
            KerasActivation(activations[2]),
            KerasDense(nodes[3], activation=activations[3]),
            Lambda(lambda xi: op.expand_dims(xi, axis=0)),
        ]
```

As you can see, right now the size is fixed (you need to give it 4 nodes, and 4 activations) but we can do whatever we want with that.
